### PR TITLE
Quickstart guide for setting up insightface chimp project on fresh lambda cloud instance

### DIFF
--- a/examples/chimp/README.md
+++ b/examples/chimp/README.md
@@ -11,7 +11,7 @@ There are multiple face detectors and landmark detectors in this insightface lib
 
 ## Installation
 
-Running the `scrfd` face detector requires some extra dependencies which adds constraint to CDUA/PyTorch version. Here are a couple of verified ways to set up the environment:
+Running the `scrfd` face detector requires some extra dependencies which adds constraint to CUDA/PyTorch version. Here are a couple of verified ways to set up the environment:
 
 **Setup insightface on a CUDA 11.6-11.8 machine**
 

--- a/examples/chimp/docs/PrepareONNX.md
+++ b/examples/chimp/docs/PrepareONNX.md
@@ -1,0 +1,48 @@
+### Prepare ONNX model for `scrdf`
+
+ONNX model for scrdf is available to download: [`scrdf_10g.onnx`](https://drive.google.com/file/d/1t4xd9tBTY4AQMSv2hXnaSwHAuZgwV2Ew/view?usp=drive_link).  
+Follow the instructions below if for any reason you need to re-generate it from the `model.path` file.
+
+
+make sure your venv is activated
+```bash
+source .venv-insightface/bin/activate
+```
+downgrade numpy:
+
+```bash
+pip install numpy==1.21.1
+```
+
+Update `site-packages/torch/onnx/utils.py` :
+
+```bash
+def _decide_input_format(model, args):
+    return args
+```
+
+Or just run this command if you are using the same .venv setup as above:
+
+```bash
+sed -i '/def _decide_input_format(model, args):/,/return args/{/def _decide_input_format(model, args):/!d}' /home/ubuntu/.venv-insightface/lib/python3.8/site-packages/torch/onnx/utils.py
+echo 'def _decide_input_format(model, args):' >> /home/ubuntu/.venv-insightface/lib/python3.8/site-packages/torch/onnx/utils.py
+echo '    return args' >> /home/ubuntu/.venv-insightface/lib/python3.8/site-packages/torch/onnx/utils.py
+```
+
+Convert to ONNX:
+
+
+```bash
+cd insightface/detection/scrfd
+export input_img='/home/ubuntu/insightface/insightface_assets/data/chimp_40/Chimp_40/Chimp_FilmRip_MVP2MostVerticalPrimate.2001.0000.png'
+export onnx_fpath='/home/ubuntu/insightface/insightface_assets/models/scrfd_10g.onnx'
+python tools/scrfd2onnx.py configs/scrfd/scrfd_10g.py \
+	/home/ubuntu/insightface/insightface_assets/models/model.pth \
+	--input-img ${input_img} \
+    --output-file ${onnx_fpath}
+```
+
+Upgrade numpy back in your venv...
+```
+pip install --upgrade numpy 
+```

--- a/examples/chimp/docs/QUICKSTART.md
+++ b/examples/chimp/docs/QUICKSTART.md
@@ -1,0 +1,75 @@
+## Fresh instance workflow
+
+### Setup insightFace
+
+Create script `install.sh`
+
+```bash
+#!/bin/bash
+sudo apt-get install -y python3-pybind11
+virtualenv -p /usr/bin/python3.8 .venv-insightface
+. .venv-insightface/bin/activate
+pip install --upgrade pip \
+    torch==1.12.1+cu116 torchvision==0.13.1+cu116 torchaudio==0.12.1 --extra-index-url https://download.pytorch.org/whl/cu116 \
+    -U openmim \
+    insightface==0.6.2 mmcv-full==1.5.0
+
+git clone https://github.com/LambdaLabsML/insightface.git
+cd insightface/detection/scrfd
+pip install -r requirements/build.txt
+pip install -v -e .
+pip install -r requirements_add.txt
+```
+
+Run install script:
+
+```bash
+sudo chmod +x install.sh
+./install.sh
+```
+
+### Setup data
+
+```bash
+storage
+|-- insightface_assets
+		|-- data
+		|   |-- chimp_50
+		|   |-- chimp_2000_0
+		|-- models
+				|-- synthetic_resnet50d.ckpt (ldkms detector)
+                |-- scrfd_10g.onnx (bbox detector)
+                |-- model.path (only use if you need to re-generate the onnx file for some reason)
+|-- .insightface-venv
+|-- insightface
+```
+
+Data sets:
+- `chimp_40` [][download](https://drive.google.com/file/d/1jcj1oafUDKY2su8PGncWwAiN6MMdlwHm/view)]
+
+Models
+- `scrfd_10g.onnx`[[download](https://drive.google.com/file/d/1t4xd9tBTY4AQMSv2hXnaSwHAuZgwV2Ew/view?usp=sharing)]
+- `synthetic_resnet50d.ckpt` [[download](https://www.notion.so/Streamlining-InsightFace-workflow-1125ab65c04849fbab1c5bc1ca64274f)]
+
+If for some reason you need to re-generate the onnx file for the scrdf_10g bbox model, refer to [this guide](PrepareONNX.md)
+The model to convert to onnx is available here: [`model.path`](https://onedrive.live.com/?authkey=%21AArBOLBe%5FaRpryg&id=4A83B6B633B029CC%215541&cid=4A83B6B633B029CC)
+
+### Training
+
+Make sure environment is activated
+
+```bash
+source .venv-insightface/bin/activate
+```
+
+```bash
+export root_dir="/home/ubuntu/insightface"
+export models_dir="${root_dir}/insightface_assets/models"
+export img_dir="${root_dir}/insightface_assets/data/chimp_40"
+
+python "${root_dir}/insightface/examples/chimp/create_data.py" \
+  --stage 'ldmks' \
+  --input_image_dir "${img_dir}" \
+  --ldmks_detector_path "${models_dir}/synthetic_resnet50d.ckpt" \
+  --bbox_detector_path "${models_dir}/crdf_10g.onnx"
+```


### PR DESCRIPTION
@chuanli11  Getting an error at the last stage; looks like it's not correctly taking into account the inputs I am passing to `create_data.py`
```
export root_dir=/home/ubuntu/insightface
export models_dir=${root_dir}/insightface_assets/models
export img_dir=${root_dir}/insightface_assets/data/chimp_40 

python insightface/examples/chimp/create_data.py \
>   --stage ldmks \
>   --input_image_dir ${img_dir} \
>   --ldmks_detector_path ${models_dir}/synthetic_resnet50d.ckpt \
>   --bbox_detector_path ${models_dir}/crdf_10g.onnx
```

returns:
```
download_path: /home/ubuntu/.insightface/models/buffalo_l
Downloading /home/ubuntu/.insightface/models/buffalo_l.zip from http://insightface.cn-sh2.ufileos.com/models/buffalo_l.zip...
Traceback (most recent call last):
  File "insightface/examples/chimp/create_data.py", line 58, in <module>
    app = FaceAnalysis()
  File "/home/ubuntu/insightface/.venv-insightface/lib/python3.8/site-packages/insightface/app/face_analysis.py", line 27, in __init__
    self.model_dir = ensure_available('models', name, root=root)
  File "/home/ubuntu/insightface/.venv-insightface/lib/python3.8/site-packages/insightface/utils/storage.py", line 30, in ensure_available
    return download(sub_dir, name, force=False, root=root)
  File "/home/ubuntu/insightface/.venv-insightface/lib/python3.8/site-packages/insightface/utils/storage.py", line 19, in download
    download_file(model_url,
  File "/home/ubuntu/insightface/.venv-insightface/lib/python3.8/site-packages/insightface/utils/download.py", line 73, in download_file
    raise RuntimeError("Failed downloading url %s" % url)
RuntimeError: Failed downloading url http://insightface.cn-sh2.ufileos.com/models/buffalo_l.zip
```